### PR TITLE
Bump dependency on base

### DIFF
--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 Library
   GHC-Options: -Wall
-  build-depends: base       >= 3   && < 4.5
+  build-depends: base       >= 3   && < 4.6
                , bytestring >= 0.9 && < 0.10
                , text       >= 0.3 && < 0.12
                , hashable   >= 1.0 && < 1.2


### PR DESCRIPTION
This is required for building on the soon to be released GHC 7.4.
