### PR TITLE
Fixed bad character L178

### DIFF
--- a/Data/CaseInsensitive/Internal.hs
+++ b/Data/CaseInsensitive/Internal.hs
@@ -175,9 +175,7 @@ toLower8 w
 -- Rewrite RULES
 --------------------------------------------------------------------------------
 
-{-# RULES
-  "mk/ByteString" forall (bs :: B.ByteString). mk bs = CI bs (foldCaseBS bs)
-  #-}
+{-# RULES "mk/ByteString" forall (bs :: B.ByteString). mk bs = CI bs (foldCaseBS bs) #-}
 
 foldCaseBS :: B.ByteString -> B.ByteString
 foldCaseBS bs = B.map toLower8' bs


### PR DESCRIPTION
case-insensitive does not compile with the rules directive on three lines on Mac OS ...
why exactly ?

Data/CaseInsensitive/Internal.hs:180:4:
     error: invalid preprocessing directive
      #-}
       ^

fixed by making it on one single line.
