### PR TITLE
Bump text upper version bounds

### DIFF
--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -27,7 +27,7 @@ Library
   ghc-options: -Wall
   build-depends: base       >= 3   && < 4.8
                , bytestring >= 0.9 && < 0.11
-               , text       >= 0.3 && < 1.2
+               , text       >= 0.3 && < 1.3
                , deepseq    >= 1.1 && < 1.4
                , hashable   >= 1.0 && < 1.3
   exposed-modules: Data.CaseInsensitive, Data.CaseInsensitive.Unsafe
@@ -41,7 +41,7 @@ test-suite test-case-insensitive
   build-depends: case-insensitive
                , base                 >= 3     && < 4.8
                , bytestring           >= 0.9   && < 0.11
-               , text                 >= 0.3   && < 1.2
+               , text                 >= 0.3   && < 1.3
                , HUnit                >= 1.2.2 && < 1.3
                , test-framework       >= 0.2.4 && < 0.9
                , test-framework-hunit >= 0.2.4 && < 0.4


### PR DESCRIPTION
Allow `case-insensitive` to use `text-1.2.0.0`
