### PR TITLE
bump base and deepseq upper bounds for GHC 7.10 compatibility

### DIFF
--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -25,10 +25,10 @@ source-repository head
 
 Library
   ghc-options: -Wall
-  build-depends: base       >= 3   && < 4.8
+  build-depends: base       >= 3   && < 4.9
                , bytestring >= 0.9 && < 0.11
                , text       >= 0.3 && < 1.3
-               , deepseq    >= 1.1 && < 1.4
+               , deepseq    >= 1.1 && < 1.5
                , hashable   >= 1.0 && < 1.3
   exposed-modules: Data.CaseInsensitive, Data.CaseInsensitive.Unsafe
   other-modules: Data.CaseInsensitive.Internal
@@ -39,7 +39,7 @@ test-suite test-case-insensitive
   hs-source-dirs: test
 
   build-depends: case-insensitive
-               , base                 >= 3     && < 4.8
+               , base                 >= 3     && < 4.9
                , bytestring           >= 0.9   && < 0.11
                , text                 >= 0.3   && < 1.3
                , HUnit                >= 1.2.2 && < 1.3
@@ -56,7 +56,7 @@ benchmark bench-case-insensitive
   ghc-options:    -Wall -O2
 
   build-depends: case-insensitive
-               , base                 >= 3     && < 4.8
+               , base                 >= 3     && < 4.9
                , bytestring           >= 0.9   && < 0.11
                , criterion            >= 0.6.1 && < 1.1
-               , deepseq              >= 1.1   && < 1.4
+               , deepseq              >= 1.1   && < 1.5


### PR DESCRIPTION
this makes it build with the current GHC HEAD
