### PR TITLE
Add Semigroup s => Semigroup (CI s) instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,94 @@
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.16 GHCVER=7.0.4
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.0.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.2.2
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.16 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.16,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.1
+      compiler: ": #GHC 8.0.1"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/Data/CaseInsensitive/Internal.hs
+++ b/Data/CaseInsensitive/Internal.hs
@@ -30,19 +30,20 @@ module Data.CaseInsensitive.Internal ( CI
 --------------------------------------------------------------------------------
 
 -- from base:
-import Data.Bool     ( (||) )
-import Data.Char     ( Char, toLower )
-import Data.Eq       ( Eq, (==) )
-import Data.Function ( on )
-import Data.Monoid   ( Monoid, mempty, mappend )
-import Data.Ord      ( Ord, compare )
-import Data.String   ( IsString, fromString )
-import Data.Data     ( Data )
-import Data.Typeable ( Typeable )
-import Data.Word     ( Word8 )
-import Prelude       ( (.), fmap, (&&), (+), (<=), otherwise )
-import Text.Read     ( Read, readPrec )
-import Text.Show     ( Show, showsPrec )
+import Data.Bool      ( (||) )
+import Data.Char      ( Char, toLower )
+import Data.Eq        ( Eq, (==) )
+import Data.Function  ( on )
+import Data.Monoid    ( Monoid, mempty, mappend )
+import Data.Ord       ( Ord, compare )
+import Data.String    ( IsString, fromString )
+import Data.Data      ( Data )
+import Data.Typeable  ( Typeable )
+import Data.Word      ( Word8 )
+import Prelude        ( (.), fmap, (&&), (+), (<=), otherwise )
+import Text.Read      ( Read, readPrec )
+import Text.Show      ( Show, showsPrec )
+import Data.Semigroup ( Semigroup, (<>) )
 
 import qualified Data.List as L ( map )
 
@@ -108,6 +109,9 @@ map f = mk . f . original
 
 instance (IsString s, FoldCase s) => IsString (CI s) where
     fromString = mk . fromString
+
+instance Semigroup s => Semigroup (CI s) where
+    CI o1 l1 <> CI o2 l2 = CI (o1 <> o2) (l1 <> l2)
 
 instance Monoid s => Monoid (CI s) where
     mempty = CI mempty mempty

--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -16,6 +16,14 @@ description:   The module @Data.CaseInsensitive@ provides the 'CI' type
                type like: 'String', 'ByteString', 'Text',
                etc.. Comparisons of values of the resulting type will be
                insensitive to cases.
+tested-with:
+  GHC==7.0.4,
+  GHC==7.2.2
+  GHC==7.4.2,
+  GHC==7.6.3,
+  GHC==7.8.4,
+  GHC==7.10.3,
+  GHC==8.0.1
 
 extra-source-files: README.markdown CHANGELOG pg2189.txt
 
@@ -25,7 +33,7 @@ source-repository head
 
 Library
   ghc-options: -Wall
-  build-depends: base       >= 3   && < 4.9
+  build-depends: base       >= 3   && < 4.10
                , bytestring >= 0.9 && < 0.11
                , text       >= 0.3 && < 1.3
                , deepseq    >= 1.1 && < 1.5
@@ -39,7 +47,7 @@ test-suite test-case-insensitive
   hs-source-dirs: test
 
   build-depends: case-insensitive
-               , base                 >= 3     && < 4.9
+               , base                 >= 3     && < 4.10
                , bytestring           >= 0.9   && < 0.11
                , text                 >= 0.3   && < 1.3
                , HUnit                >= 1.2.2 && < 1.4
@@ -56,7 +64,7 @@ benchmark bench-case-insensitive
   ghc-options:    -Wall -O2
 
   build-depends: case-insensitive
-               , base                 >= 3     && < 4.9
+               , base                 >= 3     && < 4.10
                , bytestring           >= 0.9   && < 0.11
                , criterion            >= 0.6.1 && < 1.2
                , deepseq              >= 1.1   && < 1.5

--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -38,6 +38,8 @@ Library
                , text       >= 0.3 && < 1.3
                , deepseq    >= 1.1 && < 1.5
                , hashable   >= 1.0 && < 1.3
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups >= 0.18 && < 0.19
   exposed-modules: Data.CaseInsensitive, Data.CaseInsensitive.Unsafe
   other-modules: Data.CaseInsensitive.Internal
 


### PR DESCRIPTION
 This depends on and contains the changes proposed in #19, I can rebase once that has been merged.

Data.Semigroup is part of base as of GHC 8/base-4.9.0.0, semigroups is added as a conditional dependency for older GHC versions.
