### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/case-insensitive.cabal
+++ b/case-insensitive.cabal
@@ -61,6 +61,7 @@ test-suite test-case-insensitive
 benchmark bench-case-insensitive
   type:           exitcode-stdio-1.0
   main-is:        bench.hs
+  other-modules:  NoClass
   hs-source-dirs: bench
 
   ghc-options:    -Wall -O2


### PR DESCRIPTION
Currently, the `case-insensitive` benchmarks fail to compile when obtained from Hackage since the `NoClass` file is not distributed with `cabal sdist`. This PR fixes this by putting `NoClass` in `other-modules`.

See also https://github.com/iu-parfunc/sc-haskell/issues/7