### PR TITLE
Add instance for ShortByteString

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.2.2.0
+
+* Add instance for ShortByteString
+
 1.2.1.0
 
 *  Add traverse

--- a/Data/CaseInsensitive/Internal.hs
+++ b/Data/CaseInsensitive/Internal.hs
@@ -57,6 +57,15 @@ import Prelude       ( fromInteger )
 -- from bytestring:
 import qualified Data.ByteString      as B  ( ByteString, map )
 import qualified Data.ByteString.Lazy as BL ( ByteString, map )
+-- ShortByteString appears in 0.10.4.0, without a map function but with a Data instance.
+import qualified Data.ByteString.Short as BS ( ShortByteString )
+#if MIN_VERSION_bytestring(0,11,3)
+-- This map function is better optimized, but is included only @since 0.11.3.0
+import qualified Data.ByteString.Short as BS ( map )
+#elif MIN_VERSION_bytestring(0,10,4)
+-- For maximum compatibility, we use Data's gfoldl method before bytestring-0.11.3.0
+import Data.Data (gfoldl)
+#endif
 
 -- from text:
 import qualified Data.Text      as T  ( Text, toCaseFold )
@@ -166,6 +175,12 @@ instance FoldCase B.ByteString where foldCase = B.map toLower8
 
 -- | Note that @foldCase@ on @'BL.ByteString's@ is only guaranteed to be correct for ISO-8859-1 encoded strings!
 instance FoldCase BL.ByteString where foldCase = BL.map toLower8
+
+#if MIN_VERSION_bytestring(0,11,3)
+instance FoldCase BS.ShortByteString where foldCase = BS.map toLower8
+#elif MIN_VERSION_bytestring(0,10,4)
+instance FoldCase BS.ShortByteString where foldCase = gfoldl id toLower8
+#endif
 
 instance FoldCase Char where
     foldCase     = toLower

--- a/Data/CaseInsensitive/Internal.hs
+++ b/Data/CaseInsensitive/Internal.hs
@@ -121,7 +121,7 @@ instance Semigroup s => Semigroup (CI s) where
 
 instance Monoid s => Monoid (CI s) where
     mempty = CI mempty mempty
-    CI o1 l1 `mappend` CI o2 l2 = CI (o1 `mappend` o2) (l1 `mappend` l2)
+    mappend = (<>)
 
 instance Eq s => Eq (CI s) where
     (==) = (==) `on` foldedCase

--- a/test/test.hs
+++ b/test/test.hs
@@ -23,6 +23,7 @@ main = defaultMain
                                                   (CI.mk ( BC8.map toUpper  asciiBs))
     , testCase "Lazy.ByteString" $ assertEqual "" (CI.mk                    asciiLBs)
                                                   (CI.mk (BLC8.map toUpper  asciiLBs))
+    -- TODO ShortByteString ?
     , testCase "Text"            $ assertEqual "" (CI.mk                    asciiTxt)
                                                   (CI.mk (       T.toUpper  asciiTxt))
     , testCase "Lazy.Text"       $ assertEqual "" (CI.mk                    asciiLTxt)


### PR DESCRIPTION
This fixes #23.

Not sure about the test... please LMK if you want the `#ifdef`'s in test code as well, or any other approach.

Tested on GHC 9.6.4 (only), with `bytestring-0.11.5.3`:
```
λ
λλ ➔ mk @ShortByteString "asdf" == mk "aSdF"
True
λ
λλ ➔ mk @ShortByteString "asdf" == mk "aSdF."
False
```

cc @basvandijk @winterland1989 please review.